### PR TITLE
update librdkafka version; use current multi-buildpack approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # librdkafka buildpack
 
+This buildpack compiles librdkafka for use with [confluent-kafka-python](https://github.com/confluentinc/confluent-kafka-python).
+
 ## Usage
 
-Most likely used with the multi-buildpack.
+Use with [multi-buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
-  * Set BUILDPACK_URL to your fork of [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi.git) (ignore deprecation warning)
-  * Add https://github.com/RealScout/heroku-buildpack-librdkafka.git to the `.buildpacks` file in the root of your project
+  * This buildpack expects that you have at least the heroku standard python buildpack. This buildpack should come first so that librdkafka gets installed before `pip install confluent-kafka` gets run.
+  * Set up like so:
+  ```
+  heroku buildpacks:set https://github.com/MobileWorks/heroku-buildpack-librdkafka.git
+  heroku buildpacks:add https://github.com/heroku/heroku-buildpack-python.git
+  ```

--- a/bin/compile
+++ b/bin/compile
@@ -6,10 +6,10 @@
 
 set -eo pipefail
 
-LIBRDKAFKA_VERSION=0.9.1
+LIBRDKAFKA_VERSION=0.11.3
 LIBRDKAFKA_DIST=librdkafka-${LIBRDKAFKA_VERSION}
 LIBRDKAFKA_DIST_GZ=${LIBRDKAFKA_DIST}.tar.gz
-LIBRDKAFKA_SHASUM256=5ad57e0c9a4ec8121e19f13f05bacc41556489dfe8f46ff509af567fdee98d82
+LIBRDKAFKA_SHASUM256=2b96d7ed71470b0d0027bd9f0b6eb8fb68ed979f8092611c148771eb01abb72c
 
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -38,7 +38,7 @@ fi
 # download if needed, dir won't exist in cache if checksum wasn't previously verified
 if [ ! -e $LIBRDKAFKA_DIST ];then
     # download
-    curl -Lo ${LIBRDKAFKA_DIST_GZ} https://github.com/edenhill/librdkafka/archive/${LIBRDKAFKA_VERSION}.tar.gz
+    curl -Lo ${LIBRDKAFKA_DIST_GZ} https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz
 
     # verify
     echo "${LIBRDKAFKA_SHASUM256}  ${LIBRDKAFKA_DIST_GZ}" | shasum -c -


### PR DESCRIPTION
- update librdkafka version
- move away from deprecated multi-buildpack to heroku's currently supported approach